### PR TITLE
If the dest pipe is TTY we lose the column/row information

### DIFF
--- a/mute.js
+++ b/mute.js
@@ -65,6 +65,10 @@ function setIsTTY (isTTY) {
 
 MuteStream.prototype.pipe = function (dest) {
   this._dest = dest
+  if(this._dest.isTTY){
+    this.columns = dest.columns
+    this.rows = dest.rows
+  }
   return Stream.prototype.pipe.call(this, dest)
 }
 

--- a/test/basic.js
+++ b/test/basic.js
@@ -89,17 +89,29 @@ tap.test('outgoing', function (t) {
 tap.test('isTTY', function (t) {
   var str = new PassThrough
   str.isTTY = true
+  str.columns=80
+  str.rows=24
 
   var ms = new MS
   t.equal(ms.isTTY, false)
+  t.equal(ms.columns, undefined)
+  t.equal(ms.rows, undefined)
   ms.pipe(str)
   t.equal(ms.isTTY, true)
+  t.equal(ms.columns, 80)
+  t.equal(ms.rows, 24)
   str.isTTY = false
   t.equal(ms.isTTY, false)
+  t.equal(ms.columns, 80)
+  t.equal(ms.rows, 24)
   str.isTTY = true
   t.equal(ms.isTTY, true)
+  t.equal(ms.columns, 80)
+  t.equal(ms.rows, 24)
   ms.isTTY = false
   t.equal(ms.isTTY, false)
+  t.equal(ms.columns, 80)
+  t.equal(ms.rows, 24)
 
   ms = new MS
   t.equal(ms.isTTY, false)


### PR DESCRIPTION
I noticed that when the dest is TTY we lose the column/row information.  I added a check for dest.isTTY and if so we keep the column and row properties.

I added to the isTTY test to check some column values, but I don't know if the same thing should be applied to the source pipe or not.
