### PR TITLE
fix: replace deprecated String.prototype.substr()

### DIFF
--- a/mute.js
+++ b/mute.js
@@ -102,7 +102,7 @@ MuteStream.prototype.write = function (c) {
     if (!this.replace) return true
     if (c.match(/^\u001b/)) {
       if(c.indexOf(this._prompt) === 0) {
-        c = c.substr(this._prompt.length);
+        c = c.slice(this._prompt.length);
         c = c.replace(/./g, this.replace);
         c = this._prompt + c;
       }
@@ -113,7 +113,7 @@ MuteStream.prototype.write = function (c) {
           c.indexOf(this._prompt) === 0) {
         this._hadControl = false
         this.emit('data', this._prompt)
-        c = c.substr(this._prompt.length)
+        c = c.slice(this._prompt.length)
       }
       c = c.toString().replace(/./g, this.replace)
     }


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.